### PR TITLE
Locally define decorators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,58 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/validator": "^0.92.0",
         "rimraf": "^5.0.7",
         "typescript": "^5.5.2"
+      }
+    },
+    "node_modules/@glimmer/env": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@glimmer/env/-/env-0.1.7.tgz",
+      "integrity": "sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@glimmer/global-context": {
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.92.0.tgz",
+      "integrity": "sha512-XUPXIsz/F0YQz3vY9x+u3YQMibM3378gEPJObs3CHzAWJUl9Kz1CAb+jRigRrxIcmdzoonA49VMwGmmKRNoGag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@glimmer/interfaces": {
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.0.tgz",
+      "integrity": "sha512-SKZvIs+ZPN8F3EH8kEzs7rGIUa+wuV+/3oWYyEiBrqd+VrZlmAxIELM6qZ6oxXT2tx6q1rh2EmA5rWezi6bmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/@glimmer/util": {
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.0.tgz",
+      "integrity": "sha512-Fap52smLp8RkCgvozrZG7RysNJ2T6mk1SPoknMzmukbabFVBAzxl5iyY4OXUbmR09j6t2pupjF6sPabnLtL4vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "^0.92.0"
+      }
+    },
+    "node_modules/@glimmer/validator": {
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.92.0.tgz",
+      "integrity": "sha512-GFX54PD8BRi+lg/HJ8KJRcvnV4rbDzJooQnOpJ9PlgIQi4KP/ivdjsw3DaEuvqn4K584LR6VTgHmxfZlLkDh2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/global-context": "^0.92.0",
+        "@glimmer/interfaces": "^0.92.0",
+        "@glimmer/util": "^0.92.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -18,6 +68,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -35,16 +86,25 @@
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+    "node_modules/@simple-dom/interface": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
+      "integrity": "sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -57,6 +117,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -68,13 +129,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -84,6 +147,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -95,13 +159,15 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -115,19 +181,22 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/foreground-child": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
-      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -140,10 +209,11 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
-      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -155,9 +225,6 @@
       "bin": {
         "glob": "dist/esm/bin.mjs"
       },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -167,6 +234,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -175,18 +243,17 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jackspeak": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
-      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -196,19 +263,18 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.0.tgz",
-      "integrity": "sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -224,6 +290,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -232,13 +299,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
-      "dev": true
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -248,6 +317,7 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -260,18 +330,16 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.7.tgz",
-      "integrity": "sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^10.3.7"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -282,6 +350,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -294,6 +363,7 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -303,6 +373,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -315,6 +386,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -333,6 +405,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -347,6 +420,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -355,13 +429,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -374,6 +450,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -390,6 +467,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -402,15 +480,17 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -424,6 +504,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -439,6 +520,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -457,6 +539,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -474,6 +557,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -483,6 +567,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -497,13 +582,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -518,6 +605,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   "license": "MIT",
   "description": "",
   "devDependencies": {
+    "@glimmer/env": "^0.1.7",
+    "@glimmer/validator": "^0.92.0",
     "rimraf": "^5.0.7",
     "typescript": "^5.5.2"
   }

--- a/src/action.ts
+++ b/src/action.ts
@@ -140,42 +140,8 @@ export function action(
     target: ElementDescriptor[0],
     key: ElementDescriptor[1],
     desc: ElementDescriptor[2]
-): PropertyDescriptor;
-export function action(desc: PropertyDescriptor): ExtendedMethodDecorator;
-export function action(
-    ...args: ElementDescriptor | [PropertyDescriptor]
-): PropertyDescriptor | ExtendedMethodDecorator {
+): PropertyDescriptor {
     let actionFn: object | Function;
-
-    if (!isElementDescriptor(args)) {
-        actionFn = args[0];
-
-        let decorator: ExtendedMethodDecorator = function (
-            target,
-            key,
-            _desc,
-            _meta,
-            isClassicDecorator
-        ) {
-            assert(
-                'The @action decorator may only be passed a method when used in classic classes. You should decorate methods directly in native classes',
-                isClassicDecorator
-            );
-
-            assert(
-                'The action() decorator must be passed a method when used in classic classes',
-                typeof actionFn === 'function'
-            );
-
-            return setupAction(target, key, actionFn);
-        };
-
-        setClassicDecorator(decorator);
-
-        return decorator;
-    }
-
-    let [target, key, desc] = args;
 
     actionFn = desc?.value;
 
@@ -188,5 +154,3 @@ export function action(
     return setupAction(target, key, actionFn);
 }
 
-// SAFETY: TS types are weird with decorators. This should work.
-setClassicDecorator(action as ExtendedMethodDecorator);

--- a/src/action.ts
+++ b/src/action.ts
@@ -2,7 +2,7 @@
  * Derived from https://github.com/emberjs/ember.js/blob/main/packages/%40ember/object/index.ts
  */
 
-import { assert } from '@ember/debug';
+import { assert } from './debug';
 import type { ElementDescriptor, ExtendedMethodDecorator } from '@ember/-internals/metal';
 import {
     isElementDescriptor,

--- a/src/action.ts
+++ b/src/action.ts
@@ -3,11 +3,14 @@
  */
 
 import { assert } from './debug';
-import type { ElementDescriptor, ExtendedMethodDecorator } from '@ember/-internals/metal';
-import {
-    isElementDescriptor,
-    setClassicDecorator,
-} from '@ember/-internals/metal';
+
+export type DecoratorPropertyDescriptor = (PropertyDescriptor & { initializer?: any }) | undefined;
+
+export type ElementDescriptor = [
+    target: object,
+    propertyName: string,
+    descriptor?: DecoratorPropertyDescriptor
+];
 
 /**
  Decorator that turns the target function into an Action which can be accessed

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,0 +1,311 @@
+import { assert } from '@ember/debug';
+import { ENV } from '@ember/-internals/environment';
+import type { ElementDescriptor, ExtendedMethodDecorator } from '@ember/-internals/metal';
+import {
+    isElementDescriptor,
+    expandProperties,
+    setClassicDecorator,
+} from '@ember/-internals/metal';
+import { getFactoryFor } from '@ember/-internals/container';
+import { setObservers } from '@ember/-internals/utils';
+import type { AnyFn } from '@ember/-internals/utility-types';
+import CoreObject from '@ember/object/core';
+import Observable from '@ember/object/observable';
+
+export {
+    notifyPropertyChange,
+    defineProperty,
+    get,
+    set,
+    getProperties,
+    setProperties,
+    computed,
+    trySet,
+} from '@ember/-internals/metal';
+
+/**
+ @module @ember/object
+ */
+
+/**
+ `EmberObject` is the main base class for all Ember objects. It is a subclass
+ of `CoreObject` with the `Observable` mixin applied. For details,
+ see the documentation for each of these.
+
+ @class EmberObject
+ @extends CoreObject
+ @uses Observable
+ @public
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface EmberObject extends Observable {}
+class EmberObject extends CoreObject.extend(Observable) {
+    get _debugContainerKey() {
+        let factory = getFactoryFor(this);
+        return factory !== undefined && factory.fullName;
+    }
+}
+
+export default EmberObject;
+
+/**
+ Decorator that turns the target function into an Action which can be accessed
+ directly by reference.
+
+ ```js
+ import Component from '@ember/component';
+ import { tracked } from '@glimmer/tracking';
+ import { action } from '@ember/object';
+
+ export default class Tooltip extends Component {
+ @tracked isShowing = false;
+
+ @action
+ toggleShowing() {
+ this.isShowing = !this.isShowing;
+ }
+ }
+ ```
+ ```hbs
+ <!-- template.hbs -->
+ <button {{on "click" this.toggleShowing}}>Show tooltip</button>
+
+ {{#if isShowing}}
+ <div class="tooltip">
+ I'm a tooltip!
+ </div>
+ {{/if}}
+ ```
+
+ It also binds the function directly to the instance, so it can be used in any
+ context and will correctly refer to the class it came from:
+
+ ```js
+ import Component from '@ember/component';
+ import { tracked } from '@glimmer/tracking';
+ import { action } from '@ember/object';
+
+ export default class Tooltip extends Component {
+ constructor() {
+ super(...arguments);
+
+ // this.toggleShowing is still bound correctly when added to
+ // the event listener
+ document.addEventListener('click', this.toggleShowing);
+ }
+
+ @tracked isShowing = false;
+
+ @action
+ toggleShowing() {
+ this.isShowing = !this.isShowing;
+ }
+ }
+ ```
+
+ @public
+ @method action
+ @for @ember/object
+ @static
+ @param {Function|undefined} callback The function to turn into an action,
+  when used in classic classes
+ @return {PropertyDecorator} property decorator instance
+ */
+
+const BINDINGS_MAP = new WeakMap();
+
+interface HasProto {
+    constructor: {
+        proto(): void;
+    };
+}
+
+function hasProto(obj: unknown): obj is HasProto {
+    return (
+        obj != null &&
+        (obj as any).constructor !== undefined &&
+        typeof ((obj as any).constructor as any).proto === 'function'
+    );
+}
+
+interface HasActions {
+    actions: Record<string | symbol, unknown>;
+}
+
+function setupAction(
+    target: Partial<HasActions>,
+    key: string | symbol,
+    actionFn: Function
+): TypedPropertyDescriptor<unknown> {
+    if (hasProto(target)) {
+        target.constructor.proto();
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(target, 'actions')) {
+        let parentActions = target.actions;
+        // we need to assign because of the way mixins copy actions down when inheriting
+        target.actions = parentActions ? Object.assign({}, parentActions) : {};
+    }
+
+    assert("[BUG] Somehow the target doesn't have actions!", target.actions != null);
+
+    target.actions[key] = actionFn;
+
+    return {
+        get() {
+            let bindings = BINDINGS_MAP.get(this);
+
+            if (bindings === undefined) {
+                bindings = new Map();
+                BINDINGS_MAP.set(this, bindings);
+            }
+
+            let fn = bindings.get(actionFn);
+
+            if (fn === undefined) {
+                fn = actionFn.bind(this);
+                bindings.set(actionFn, fn);
+            }
+
+            return fn;
+        },
+    };
+}
+
+export function action(
+    target: ElementDescriptor[0],
+    key: ElementDescriptor[1],
+    desc: ElementDescriptor[2]
+): PropertyDescriptor;
+export function action(desc: PropertyDescriptor): ExtendedMethodDecorator;
+export function action(
+    ...args: ElementDescriptor | [PropertyDescriptor]
+): PropertyDescriptor | ExtendedMethodDecorator {
+    let actionFn: object | Function;
+
+    if (!isElementDescriptor(args)) {
+        actionFn = args[0];
+
+        let decorator: ExtendedMethodDecorator = function (
+            target,
+            key,
+            _desc,
+            _meta,
+            isClassicDecorator
+        ) {
+            assert(
+                'The @action decorator may only be passed a method when used in classic classes. You should decorate methods directly in native classes',
+                isClassicDecorator
+            );
+
+            assert(
+                'The action() decorator must be passed a method when used in classic classes',
+                typeof actionFn === 'function'
+            );
+
+            return setupAction(target, key, actionFn);
+        };
+
+        setClassicDecorator(decorator);
+
+        return decorator;
+    }
+
+    let [target, key, desc] = args;
+
+    actionFn = desc?.value;
+
+    assert(
+        'The @action decorator must be applied to methods when used in native classes',
+        typeof actionFn === 'function'
+    );
+
+    // SAFETY: TS types are weird with decorators. This should work.
+    return setupAction(target, key, actionFn);
+}
+
+// SAFETY: TS types are weird with decorators. This should work.
+setClassicDecorator(action as ExtendedMethodDecorator);
+
+// ..........................................................
+// OBSERVER HELPER
+//
+
+type ObserverDefinition<T extends AnyFn> = {
+    dependentKeys: string[];
+    fn: T;
+    sync: boolean;
+};
+
+/**
+ Specify a method that observes property changes.
+
+ ```javascript
+ import EmberObject from '@ember/object';
+ import { observer } from '@ember/object';
+
+ export default EmberObject.extend({
+ valueObserver: observer('value', function() {
+ // Executes whenever the "value" property changes
+ })
+ });
+ ```
+
+ Also available as `Function.prototype.observes` if prototype extensions are
+ enabled.
+
+ @method observer
+ @for @ember/object
+ @param {String} propertyNames*
+ @param {Function} func
+ @return func
+ @public
+ @static
+ */
+export function observer<T extends AnyFn>(
+    ...args:
+        | [propertyName: string, ...additionalPropertyNames: string[], func: T]
+        | [ObserverDefinition<T>]
+): T {
+    let funcOrDef = args.pop();
+
+    assert(
+        'observer must be provided a function or an observer definition',
+        typeof funcOrDef === 'function' || (typeof funcOrDef === 'object' && funcOrDef !== null)
+    );
+
+    let func: T;
+    let dependentKeys: string[];
+    let sync: boolean;
+
+    if (typeof funcOrDef === 'function') {
+        func = funcOrDef;
+        dependentKeys = args as string[];
+        sync = !ENV._DEFAULT_ASYNC_OBSERVERS;
+    } else {
+        func = funcOrDef.fn;
+        dependentKeys = funcOrDef.dependentKeys;
+        sync = funcOrDef.sync;
+    }
+
+    assert('observer called without a function', typeof func === 'function');
+    assert(
+        'observer called without valid path',
+        Array.isArray(dependentKeys) &&
+        dependentKeys.length > 0 &&
+        dependentKeys.every((p) => typeof p === 'string' && Boolean(p.length))
+    );
+    assert('observer called without sync', typeof sync === 'boolean');
+
+    let paths: string[] = [];
+
+    for (let dependentKey of dependentKeys) {
+        expandProperties(dependentKey, (path: string) => paths.push(path));
+    }
+
+    setObservers(func as Function, {
+        paths,
+        sync,
+    });
+    return func;
+}

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,52 +1,13 @@
+/**
+ * Derived from https://github.com/emberjs/ember.js/blob/main/packages/%40ember/object/index.ts
+ */
+
 import { assert } from '@ember/debug';
-import { ENV } from '@ember/-internals/environment';
 import type { ElementDescriptor, ExtendedMethodDecorator } from '@ember/-internals/metal';
 import {
     isElementDescriptor,
-    expandProperties,
     setClassicDecorator,
 } from '@ember/-internals/metal';
-import { getFactoryFor } from '@ember/-internals/container';
-import { setObservers } from '@ember/-internals/utils';
-import type { AnyFn } from '@ember/-internals/utility-types';
-import CoreObject from '@ember/object/core';
-import Observable from '@ember/object/observable';
-
-export {
-    notifyPropertyChange,
-    defineProperty,
-    get,
-    set,
-    getProperties,
-    setProperties,
-    computed,
-    trySet,
-} from '@ember/-internals/metal';
-
-/**
- @module @ember/object
- */
-
-/**
- `EmberObject` is the main base class for all Ember objects. It is a subclass
- of `CoreObject` with the `Observable` mixin applied. For details,
- see the documentation for each of these.
-
- @class EmberObject
- @extends CoreObject
- @uses Observable
- @public
- */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface EmberObject extends Observable {}
-class EmberObject extends CoreObject.extend(Observable) {
-    get _debugContainerKey() {
-        let factory = getFactoryFor(this);
-        return factory !== undefined && factory.fullName;
-    }
-}
-
-export default EmberObject;
 
 /**
  Decorator that turns the target function into an Action which can be accessed
@@ -226,86 +187,3 @@ export function action(
 
 // SAFETY: TS types are weird with decorators. This should work.
 setClassicDecorator(action as ExtendedMethodDecorator);
-
-// ..........................................................
-// OBSERVER HELPER
-//
-
-type ObserverDefinition<T extends AnyFn> = {
-    dependentKeys: string[];
-    fn: T;
-    sync: boolean;
-};
-
-/**
- Specify a method that observes property changes.
-
- ```javascript
- import EmberObject from '@ember/object';
- import { observer } from '@ember/object';
-
- export default EmberObject.extend({
- valueObserver: observer('value', function() {
- // Executes whenever the "value" property changes
- })
- });
- ```
-
- Also available as `Function.prototype.observes` if prototype extensions are
- enabled.
-
- @method observer
- @for @ember/object
- @param {String} propertyNames*
- @param {Function} func
- @return func
- @public
- @static
- */
-export function observer<T extends AnyFn>(
-    ...args:
-        | [propertyName: string, ...additionalPropertyNames: string[], func: T]
-        | [ObserverDefinition<T>]
-): T {
-    let funcOrDef = args.pop();
-
-    assert(
-        'observer must be provided a function or an observer definition',
-        typeof funcOrDef === 'function' || (typeof funcOrDef === 'object' && funcOrDef !== null)
-    );
-
-    let func: T;
-    let dependentKeys: string[];
-    let sync: boolean;
-
-    if (typeof funcOrDef === 'function') {
-        func = funcOrDef;
-        dependentKeys = args as string[];
-        sync = !ENV._DEFAULT_ASYNC_OBSERVERS;
-    } else {
-        func = funcOrDef.fn;
-        dependentKeys = funcOrDef.dependentKeys;
-        sync = funcOrDef.sync;
-    }
-
-    assert('observer called without a function', typeof func === 'function');
-    assert(
-        'observer called without valid path',
-        Array.isArray(dependentKeys) &&
-        dependentKeys.length > 0 &&
-        dependentKeys.every((p) => typeof p === 'string' && Boolean(p.length))
-    );
-    assert('observer called without sync', typeof sync === 'boolean');
-
-    let paths: string[] = [];
-
-    for (let dependentKey of dependentKeys) {
-        expandProperties(dependentKey, (path: string) => paths.push(path));
-    }
-
-    setObservers(func as Function, {
-        paths,
-        sync,
-    });
-    return func;
-}

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,5 @@
+export function assert(desc: string, test: unknown): asserts test {
+    if (!test) {
+        throw new Error(`Assertion Failed: ${desc}`);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export * from './myModule.js';
+export * from './actions.js'
+export * from './tracked.js'

--- a/src/tracked.ts
+++ b/src/tracked.ts
@@ -67,8 +67,10 @@ export function setPropertyDidChange(cb: () => void) {
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const tracked: PropertyDecorator = (...args: any[]) => {
-    const [target, key, descriptor] = args;
+export function tracked<T extends object>(target: T, propertyKey: keyof T): void;
+export function tracked<T extends object>(target: T, propertyKey: keyof T, descriptor: PropertyDescriptor): PropertyDescriptor;
+export function tracked<T extends object>(...args: [target: T, propertyKey: keyof T, descriptor?: PropertyDescriptor]): PropertyDescriptor | void {
+    const [target, key, descriptor ] = args;
 
     // Error on `@tracked()`, `@tracked(...args)`, and `@tracked get propName()`
     if (DEBUG && typeof target === 'string') throwTrackedWithArgumentsError(args);

--- a/src/tracked.ts
+++ b/src/tracked.ts
@@ -5,6 +5,11 @@
 import { DEBUG } from '@glimmer/env';
 import { trackedData } from '@glimmer/validator';
 
+let propertyDidChange = function () { };
+export function setPropertyDidChange(cb: () => void) {
+    propertyDidChange = cb;
+}
+
 /**
  * @decorator
  *
@@ -145,6 +150,7 @@ function descriptorForField<T extends object, K extends keyof T>(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         set(this: T, newValue: any): void {
             setter(this, newValue);
+            propertyDidChange();
         },
     };
 }

--- a/src/tracked.ts
+++ b/src/tracked.ts
@@ -1,0 +1,150 @@
+/**
+ * Source derived from https://github.com/glimmerjs/glimmer.js/blob/master/packages/%40glimmer/tracking/src/tracked.ts
+ */
+
+import { DEBUG } from '@glimmer/env';
+import { trackedData } from '@glimmer/validator';
+
+/**
+ * @decorator
+ *
+ * Marks a property as tracked.
+ *
+ * By default, a component's properties are expected to be static,
+ * meaning you are not able to update them and have the template update accordingly.
+ * Marking a property as tracked means that when that property changes,
+ * a rerender of the component is scheduled so the template is kept up to date.
+ *
+ * @example
+ *
+ * ```typescript
+ * import Component from '@glimmer/component';
+ * import { tracked } from '@glimmer/tracking';
+ *
+ * export default class MyComponent extends Component {
+ *    @tracked
+ *    remainingApples = 10
+ * }
+ * ```
+ *
+ * When something changes the component's `remainingApples` property, the rerender
+ * will be scheduled.
+ *
+ * @example Computed Properties
+ *
+ * In the case that you have a getter that depends on other properties, tracked
+ * properties accessed within the getter will automatically be tracked for you.
+ * That means when any of those dependent tracked properties is changed, a
+ * rerender of the component will be scheduled.
+ *
+ * In the following example we have two properties,
+ * `eatenApples`, and `remainingApples`.
+ *
+ *
+ * ```typescript
+ * import Component from '@glimmer/component';
+ * import { tracked } from '@glimmer/tracking';
+ *
+ * const totalApples = 100;
+ *
+ * export default class MyComponent extends Component {
+ *    @tracked
+ *    eatenApples = 0
+ *
+ *    get remainingApples() {
+ *      return totalApples - this.eatenApples;
+ *    }
+ *
+ *    increment() {
+ *      this.eatenApples = this.eatenApples + 1;
+ *    }
+ *  }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const tracked: PropertyDecorator = (...args: any[]) => {
+    const [target, key, descriptor] = args;
+
+    // Error on `@tracked()`, `@tracked(...args)`, and `@tracked get propName()`
+    if (DEBUG && typeof target === 'string') throwTrackedWithArgumentsError(args);
+    if (DEBUG && target === undefined) throwTrackedWithEmptyArgumentsError();
+    if (DEBUG && descriptor && descriptor.get) throwTrackedComputedPropertyError();
+
+    if (descriptor) {
+        return descriptorForField(target, key, descriptor);
+    }
+    // In TypeScript's implementation, decorators on simple class fields do not
+    // receive a descriptor, so we define the property on the target directly.
+    Object.defineProperty(target, key, descriptorForField(target, key));
+};
+
+function throwTrackedComputedPropertyError(): never {
+    throw new Error(
+        `The @tracked decorator does not need to be applied to getters. Properties implemented using a getter will recompute automatically when any tracked properties they access change.`
+    );
+}
+
+function throwTrackedWithArgumentsError(args: unknown[]): never {
+    throw new Error(
+        `You attempted to use @tracked with ${
+            args.length > 1 ? 'arguments' : 'an argument'
+        } ( @tracked(${args
+            .map((d) => `'${d}'`)
+            .join(
+                ', '
+            )}) ), which is no longer necessary nor supported. Dependencies are now automatically tracked, so you can just use ${'`@tracked`'}.`
+    );
+}
+
+function throwTrackedWithEmptyArgumentsError(): never {
+    throw new Error(
+        'You attempted to use @tracked(), which is no longer necessary nor supported. Remove the parentheses and you will be good to go!'
+    );
+}
+
+/**
+ * Whenever a tracked computed property is entered, the current tracker is
+ * saved off and a new tracker is replaced.
+ *
+ * Any tracked properties consumed are added to the current tracker.
+ *
+ * When a tracked computed property is exited, the tracker's tags are
+ * combined and added to the parent tracker.
+ *
+ * The consequence is that each tracked computed property has a tag
+ * that corresponds to the tracked properties consumed inside of
+ * itself, including child tracked computed properties.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DecoratorPropertyDescriptor = (PropertyDescriptor & { initializer?: any }) | undefined;
+
+function descriptorForField<T extends object, K extends keyof T>(
+    _target: T,
+    key: K,
+    desc?: DecoratorPropertyDescriptor
+): PropertyDescriptor {
+    if (DEBUG && desc && (desc.value || desc.get || desc.set)) {
+        throw new Error(
+            `You attempted to use @tracked on ${String(
+                key
+            )}, but that element is not a class field. @tracked is only usable on class fields. Native getters and setters will autotrack add any tracked fields they encounter, so there is no need mark getters and setters with @tracked.`
+        );
+    }
+
+    const { getter, setter } = trackedData<T, K>(key, desc && desc.initializer);
+
+    return {
+        enumerable: true,
+        configurable: true,
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        get(this: T): any {
+            return getter(this);
+        },
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        set(this: T, newValue: any): void {
+            setter(this, newValue);
+        },
+    };
+}


### PR DESCRIPTION
Locally define @action and @tracked decorators.

The ember versions are too closely entwined.  

Also importing @glimmer/tracked resulted in @glimmer/validator being installed locally to @glimmer/tracked rather than at the root node_modules.  Leading to incompatible caches.